### PR TITLE
Zach/adaptive rho

### DIFF
--- a/rlaopt/preconditioners/configs.py
+++ b/rlaopt/preconditioners/configs.py
@@ -107,7 +107,6 @@ class SkPreConfig(PreconditionerConfig):
     sketch_size: int
     rho: float
     sketch: str = "sparse"
-    damping_strategy: str = "non_adaptive"
 
     def __post_init__(self):
         """Validate the configuration parameters after initialization."""

--- a/rlaopt/preconditioners/nystrom.py
+++ b/rlaopt/preconditioners/nystrom.py
@@ -108,4 +108,20 @@ class Nystrom(Preconditioner):
         x = 1 / self.config.rho * (x - self.U @ UTx) + self.U @ torch.divide(
             UTx, self.S + self.config.rho
         )
+
+        return x
+
+    def _apply_inverse_sqrt(self, x: torch.Tensor) -> torch.Tensor:
+        """Applies inverse square root of the preconditioner to a tensor.
+
+           Args:
+            x (torch.Tensor): The tensor to multiply with.
+
+        Returns:
+            torch.Tensor: The result of the inverse square root matrix multiplication.
+        """
+        UTx = self.U.T @ x
+        x = 1 / (self.config.rho) ** (0.5) * (x - self.U @ UTx) + self.U @ torch.divide(
+            UTx, (self.S + self.config.rho) ** (0.5)
+        )
         return x

--- a/rlaopt/spectral_estimators/__init__.py
+++ b/rlaopt/spectral_estimators/__init__.py
@@ -1,0 +1,1 @@
+"Spectral estimators module __init__.py file."

--- a/rlaopt/spectral_estimators/frobenius_norm.py
+++ b/rlaopt/spectral_estimators/frobenius_norm.py
@@ -1,0 +1,20 @@
+from typing import Tuple
+
+from rlaopt.linops.simple import TwoSidedLinOp, SymmetricLinOp
+
+from .trace import hutchinson
+
+def fro_norm_est(
+        A: TwoSidedLinOp,
+        k: int,
+        sketch: str
+)->Tuple[float]:
+    
+    G = SymmetricLinOp(
+           A.device, 
+           A.shape,
+           matvec=lambda v: A.T @ (A @ v)
+       )
+       
+
+    return hutchinson(G, k, sketch)

--- a/rlaopt/spectral_estimators/spectral_norm.py
+++ b/rlaopt/spectral_estimators/spectral_norm.py
@@ -1,0 +1,29 @@
+"""Functions for estimating spectral norm of matrices/linops."""
+
+from typing import Union, Tuple
+
+import torch
+
+from rlaopt.linops.simple import SymmetricLinOp
+
+def randomized_powering(
+        A: Union[SymmetricLinOp, torch.Tensor],
+        num_iters: int = 10,
+        rtol: float = 10**-3 
+)->Tuple[float, torch.Tensor]:
+    
+    d = A.shape[0]
+    omega = torch.randn(d, device=A.device)
+    v = omega / torch.linalg.norm(omega, 2)
+
+    i = 0
+    err = torch.inf
+    sig = 0.0
+    while i<num_iters and err > rtol * sig:
+        v_new = A @ v
+        sig_new = torch.dot(v, v_new)
+        v = v_new / torch.linalg.norm(v_new, 2)
+        err = torch.abs(sig_new - sig)
+        sig = sig_new
+        i+=1
+    return sig_new, v

--- a/rlaopt/spectral_estimators/trace.py
+++ b/rlaopt/spectral_estimators/trace.py
@@ -1,0 +1,29 @@
+"""Module containing Hutchinson type methods for trace estimation."""
+
+from typing import Tuple, Union
+
+import torch
+
+from rlaopt.linops.simple import SymmetricLinOp
+from rlaopt.preconditioners.sketches.sketch_factory import get_sketch
+
+def hutchinson(
+        A: SymmetricLinOp, 
+        k: int,
+        sketch: str
+)->Tuple[float,float]:
+    
+    Omega = get_sketch(sketch, "left", k, A.shape[0], A.device)
+    Omega_A = Omega._apply_left(A)
+    Omega_A_Omega_T = Omega._apply_right_trans(Omega_A)
+    d = Omega_A_Omega_T.diag()
+    trace = torch.sum(d)
+    var = 1 / (k - 1) * torch.sum(k * d - trace)
+    return trace, var
+
+def hutch_plus_plus(
+        A: Union[SymmetricLinOp, torch.Tensor],
+        k: int,
+        sketch: str
+)->float:
+    pass

--- a/rlaopt/utils/input_checkers.py
+++ b/rlaopt/utils/input_checkers.py
@@ -19,6 +19,7 @@ __all__ = [
     "_is_pos_float",
     "_is_pos_int",
     "_is_sketch",
+    "_is_strategy"
 ]
 
 
@@ -123,13 +124,13 @@ def _is_pos_int(param: Any, param_name: str):
 
 def _is_sketch(sketch: str):
     valid_sketches = ["gauss", "ortho", "sparse"]
-    if sketch not in ["gauss", "ortho", "sparse"]:
+    if sketch not in valid_sketches:
         raise ValueError(f"sketch must be in {valid_sketches}, but received {sketch}")
 
 
 def _is_strategy(damping_strategy: str):
     valid_strategies = ["adaptive", "non_adaptive"]
-    if damping_strategy not in [valid_strategies]:
+    if damping_strategy not in valid_strategies:
         raise ValueError(
             f"strategy must be in {valid_strategies}, but received {damping_strategy}"
         )


### PR DESCRIPTION
- Adds support for adaptive selection of rho to SAP and PCG, following the strategy of Rathore et al. 2025
- Adds beta spectral_estimator module, currently only randomized_powering is used for SAP
- Adds a method to the Nyström preconditioner for applying the inverse square root. 
- Updates input_checkers for determining whether the damping strategy is valid.