### PR TITLE
fix precond_config default in solver configs

### DIFF
--- a/rlaopt/solvers/configs.py
+++ b/rlaopt/solvers/configs.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import Any
 
 import torch

--- a/rlaopt/solvers/configs.py
+++ b/rlaopt/solvers/configs.py
@@ -70,7 +70,7 @@ class PCGConfig(SolverConfig):
     max_iters: int = 1000
     atol: float = 0.0
     rtol: float = 1e-5
-    precond_config: PreconditionerConfig = IdentityConfig()
+    precond_config: PreconditionerConfig = field(default_factory=IdentityConfig)
 
     def __post_init__(self):
         _is_torch_device(self.device, "device")
@@ -86,7 +86,7 @@ class SAPConfig(SolverConfig):
     max_iters: int = 1000
     atol: float = 0.0
     rtol: float = 1e-5
-    precond_config: PreconditionerConfig = IdentityConfig()
+    precond_config: PreconditionerConfig = field(default_factory=IdentityConfig)
     blk_sz: int
     accel: bool = True
     accel_config: SAPAccelConfig | None = None


### PR DESCRIPTION
In python 3.12, setting `precond_config: PreconditionerConfig = IdentityConfig()` by default leads to an error. We fix this by using `precond_config: PreconditionerConfig = field(default_factory=IdentityConfig`.