### PR TITLE
Fix issue in NAryOperatorExpression that was causing pytest failures

### DIFF
--- a/rlaopt/expression/expression.py
+++ b/rlaopt/expression/expression.py
@@ -197,7 +197,16 @@ class NAryOperatorExpression(Expression, ABC):
         super().__init__()
         if len(exprs) == 0:
             raise ValueError(f"{self.__class__.__name__} requires at least one operand")
-        self.exprs = torch.nn.ModuleList([to_expr(e) for e in exprs])
+        else:
+            if exprs[-1] is not None:
+                self.exprs = torch.nn.ModuleList([to_expr(e) for e in exprs])
+            else:
+                # If last expr is None, ignore it
+                # This is needed for operator_split in AddExpression
+                # As right can be None there
+                self.exprs = torch.nn.ModuleList(
+                    [to_expr(e) for e in exprs[:-1]]
+                )  # ignore last None
 
     def is_smooth(self) -> bool:
         return all(expr.is_smooth() for expr in self.exprs)
@@ -267,7 +276,6 @@ class AddExpression(NAryOperatorExpression):
 
         smooth = [e for e in self.exprs if e.is_smooth()]
         non_smooth = [e for e in self.exprs if not e.is_smooth()]
-
         smooth_expr = AddExpression(*smooth) if smooth else None
         non_smooth_expr = AddExpression(*non_smooth) if non_smooth else None
 

--- a/test.ipynb
+++ b/test.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c4b7e9d4",
    "metadata": {},
    "outputs": [],
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "23c0171c",
    "metadata": {},
    "outputs": [],
@@ -56,75 +56,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "208ac137",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ProductExpression(\n",
-       "  (exprs): ModuleList(\n",
-       "    (0): ConstExpression()\n",
-       "    (1): UnaryOpExpression(\n",
-       "      (operand): UnaryOpExpression(\n",
-       "        (operand): AddExpression(\n",
-       "          (exprs): ModuleList(\n",
-       "            (0): ProductExpression(\n",
-       "              (exprs): ModuleList(\n",
-       "                (0): ConstExpression()\n",
-       "                (1): Variable(name='var1', id='1', shape=(10,), dtype=torch.float32, device='cpu', requires_grad=True)\n",
-       "              )\n",
-       "            )\n",
-       "            (1): ConstExpression()\n",
-       "          )\n",
-       "        )\n",
-       "        (_operand): AddExpression(\n",
-       "          (exprs): ModuleList(\n",
-       "            (0): ProductExpression(\n",
-       "              (exprs): ModuleList(\n",
-       "                (0): ConstExpression()\n",
-       "                (1): Variable(name='var1', id='1', shape=(10,), dtype=torch.float32, device='cpu', requires_grad=True)\n",
-       "              )\n",
-       "            )\n",
-       "            (1): ConstExpression()\n",
-       "          )\n",
-       "        )\n",
-       "      )\n",
-       "      (_operand): UnaryOpExpression(\n",
-       "        (operand): AddExpression(\n",
-       "          (exprs): ModuleList(\n",
-       "            (0): ProductExpression(\n",
-       "              (exprs): ModuleList(\n",
-       "                (0): ConstExpression()\n",
-       "                (1): Variable(name='var1', id='1', shape=(10,), dtype=torch.float32, device='cpu', requires_grad=True)\n",
-       "              )\n",
-       "            )\n",
-       "            (1): ConstExpression()\n",
-       "          )\n",
-       "        )\n",
-       "        (_operand): AddExpression(\n",
-       "          (exprs): ModuleList(\n",
-       "            (0): ProductExpression(\n",
-       "              (exprs): ModuleList(\n",
-       "                (0): ConstExpression()\n",
-       "                (1): Variable(name='var1', id='1', shape=(10,), dtype=torch.float32, device='cpu', requires_grad=True)\n",
-       "              )\n",
-       "            )\n",
-       "            (1): ConstExpression()\n",
-       "          )\n",
-       "        )\n",
-       "      )\n",
-       "    )\n",
-       "  )\n",
-       ")"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "f"
    ]
@@ -269,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "8e64be62",
    "metadata": {},
    "outputs": [],
@@ -290,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "47279e02",
    "metadata": {},
    "outputs": [],
@@ -302,13 +237,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "693cc6b6",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Lasso problem\n",
     "F = SumSquares(A @ x - b) + L1Norm(x, scaling=mu)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2a2b800e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f,r = F.operator_split()"
    ]
   },
   {


### PR DESCRIPTION
Modifies NAryOperatorExpression to handle the case when exprs[-1] is None. Previously this case wasn't handled which led to issues when operator_split was being called in AddExpression, as right is None in that case.