### PR TITLE
Rename `ConstExpression` to `Constant`

### DIFF
--- a/rlaopt/expression/__init__.py
+++ b/rlaopt/expression/__init__.py
@@ -1,6 +1,6 @@
 """__init__ file for expression module."""
 
-from rlaopt.expression.constant import ConstExpression as ConstExpression
+from rlaopt.expression.constant import Constant as Constant
 from rlaopt.expression.expression import Expression as Expression
 from rlaopt.expression.op_expressions import AddExpression as AddExpression
 from rlaopt.expression.op_expressions import ProductExpression as ProductExpression

--- a/rlaopt/expression/constant.py
+++ b/rlaopt/expression/constant.py
@@ -1,4 +1,4 @@
-"""Module for ConstExpression class."""
+"""Module for Constant class."""
 
 import torch
 
@@ -6,7 +6,7 @@ from rlaopt.expression.expression import Expression
 from rlaopt.expression.tree import ExprTree
 
 
-class ConstExpression(Expression):
+class Constant(Expression):
     """Constant value expression.
 
     Represents a constant (non-trainable) value in an expression tree.
@@ -20,10 +20,10 @@ class ConstExpression(Expression):
         _value: The constant value stored as a buffer.
 
     Examples:
-        >>> c = ConstExpression(3.14)
+        >>> c = Constant(3.14)
         >>> c.forward()
         tensor(3.1400)
-        >>> c2 = ConstExpression(torch.ones(5))
+        >>> c2 = Constant(torch.ones(5))
         >>> c2.forward().shape
         torch.Size([5])
     """
@@ -74,17 +74,17 @@ class ConstExpression(Expression):
         return self.value
 
     def tree(self) -> ExprTree:
-        """Return tree representation for ConstExpression (leaf node).
+        """Return tree representation for Constant (leaf node).
 
         Returns:
-            ExprTree: Leaf node with type 'ConstExpression'.
+            ExprTree: Leaf node with type 'Constant'.
         """
-        return ExprTree("ConstExpression")
+        return ExprTree("Constant")
 
     def __neg__(self):
         """Negate the constant (keeps it as a constant).
 
         Returns:
-            ConstExpression: Negated constant.
+            Constant: Negated constant.
         """
-        return ConstExpression(-self.value)
+        return Constant(-self.value)

--- a/rlaopt/expression/expr_types.py
+++ b/rlaopt/expression/expr_types.py
@@ -37,10 +37,10 @@ def prod_expr():
 
 
 def constant():
-    """Return ConstExpression class to avoid circular imports."""
+    """Return Constant class to avoid circular imports."""
     from rlaopt.expression import constant
 
-    return constant.ConstExpression
+    return constant.Constant
 
 
 def variable():

--- a/rlaopt/expression/op_expressions.py
+++ b/rlaopt/expression/op_expressions.py
@@ -6,7 +6,7 @@ import torch
 
 from rlaopt.expression import expr_types
 from rlaopt.expression._nary_op_expression import _NAryOpExpression
-from rlaopt.expression.constant import ConstExpression
+from rlaopt.expression.constant import Constant
 from rlaopt.expression.expression import Expression
 from rlaopt.ext_tensordict import TensorDict
 
@@ -256,7 +256,7 @@ class ProductExpression(_NAryOpExpression):
         Returns:
             bool: True if tree contains only simple expressions.
         """
-        if isinstance(expr, (expr_types.variable(), ConstExpression)):
+        if isinstance(expr, (expr_types.variable(), Constant)):
             return True
         if isinstance(expr, (ProductExpression, AddExpression)):
             return all(self._is_var_or_const_tree(child) for child in expr.exprs)

--- a/rlaopt/expression/utils.py
+++ b/rlaopt/expression/utils.py
@@ -20,7 +20,7 @@ def _create_add(left, right):
         right: Right operand (Expression, float, int, or torch.Tensor).
 
     Returns:
-        Expression: Optimized sum (AddExpression, ConstExpression, or single expr).
+        Expression: Optimized sum (AddExpression, Constant, or single expr).
     """
     # Convert inputs to expressions if needed
     left = _to_expr(left)
@@ -79,7 +79,7 @@ def _create_product(left, right, matmul: bool):
         matmul: If True, use matrix multiplication (no optimizations).
 
     Returns:
-        ProductExpression, AddExpression (if distributed), ConstExpression
+        ProductExpression, AddExpression (if distributed), Constant
         (if all constants fold), or AtomExpression (if scaled atom).
     """
     # Convert inputs to expressions if needed

--- a/tests/atoms/test_atom_expression.py
+++ b/tests/atoms/test_atom_expression.py
@@ -144,7 +144,7 @@ class TestTree:
             ExprTree(
                 "AddExpression",
                 ExprTree("Variable(x)"),
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 is_commutative=True,
             ),
         )

--- a/tests/expression/test_constant.py
+++ b/tests/expression/test_constant.py
@@ -4,29 +4,29 @@ import pytest
 import torch
 
 from rlaopt.expression import ExprTree
-from rlaopt.expression.constant import ConstExpression
+from rlaopt.expression.constant import Constant
 
 
 @pytest.fixture
 def scalar_const():
     """Create a scalar constant expression."""
-    return ConstExpression(3.14)
+    return Constant(3.14)
 
 
 @pytest.fixture
 def int_const():
     """Create an integer constant expression."""
-    return ConstExpression(5)
+    return Constant(5)
 
 
 @pytest.fixture
 def tensor_const():
     """Create a tensor constant expression."""
-    return ConstExpression(torch.tensor([1.0, 2.0, 3.0]))
+    return Constant(torch.tensor([1.0, 2.0, 3.0]))
 
 
-class TestConstExpression:
-    """Test ConstExpression concrete implementation."""
+class TestConstant:
+    """Test Constant concrete implementation."""
 
     # ----------------------
     # Initialization tests
@@ -74,7 +74,7 @@ class TestConstExpression:
 
     def test_tree(self, scalar_const):
         """Test tree() returns correct structure."""
-        assert scalar_const.tree() == ExprTree("ConstExpression")
+        assert scalar_const.tree() == ExprTree("Constant")
 
     # ----------------------
     # Forward evaluation tests
@@ -100,9 +100,9 @@ class TestConstExpression:
     # ----------------------
 
     def test_neg_returns_const_expression(self, scalar_const):
-        """Test __neg__ returns a ConstExpression."""
+        """Test __neg__ returns a Constant."""
         result = -scalar_const
-        assert isinstance(result, ConstExpression)
+        assert isinstance(result, Constant)
 
     def test_neg_negates_scalar_value(self, scalar_const):
         """Test __neg__ correctly negates scalar constant."""
@@ -131,24 +131,24 @@ class TestConstExpression:
 
     def test_zero_constant(self):
         """Test constant with zero value."""
-        zero_const = ConstExpression(0)
+        zero_const = Constant(0)
         assert torch.equal(zero_const.value, torch.tensor(0))
         assert zero_const.forward().item() == 0
 
     def test_negative_constant(self):
         """Test constant with negative value."""
-        neg_const = ConstExpression(-5.5)
+        neg_const = Constant(-5.5)
         assert torch.allclose(neg_const.value, torch.tensor(-5.5))
 
     def test_multidimensional_tensor_constant(self):
         """Test constant with multidimensional tensor."""
         matrix = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)
-        matrix_const = ConstExpression(matrix)
+        matrix_const = Constant(matrix)
         assert torch.equal(matrix_const.value, matrix)
         assert matrix_const.forward().shape == (2, 2)
 
     def test_empty_tensor_constant(self):
         """Test constant with empty tensor."""
-        empty_const = ConstExpression(torch.tensor([]))
+        empty_const = Constant(torch.tensor([]))
         assert empty_const.value.numel() == 0
         assert empty_const.forward().shape == (0,)

--- a/tests/expression/test_expression.py
+++ b/tests/expression/test_expression.py
@@ -208,9 +208,7 @@ class TestExpression:
 
         result = a + b + c
 
-        _assert_expression_equals(
-            result, ExprTree("ConstExpression"), torch.tensor(6.0)
-        )
+        _assert_expression_equals(result, ExprTree("Constant"), torch.tensor(6.0))
 
     def test_addition_flattening(self):
         """Test that (a + b) + c flattens to AddExpression(a, b, c)."""
@@ -225,7 +223,7 @@ class TestExpression:
             result,
             ExprTree(
                 "AddExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree("Variable(x)"),
                 is_commutative=True,
             ),
@@ -251,7 +249,7 @@ class TestExpression:
             result,
             ExprTree(
                 "AddExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree("Variable(x)"),
                 is_commutative=True,
             ),
@@ -268,10 +266,10 @@ class TestExpression:
             result,
             ExprTree(
                 "AddExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(x)"),
                     is_commutative=True,
                 ),
@@ -299,7 +297,7 @@ class TestExpression:
 
         _assert_expression_equals(
             result,
-            ExprTree("ConstExpression"),
+            ExprTree("Constant"),
             torch.tensor([[11.0, 12.0], [13.0, 14.0]]),
         )
 
@@ -312,7 +310,7 @@ class TestExpression:
 
         _assert_expression_equals(
             result,
-            ExprTree("ConstExpression"),
+            ExprTree("Constant"),
             torch.tensor([[11.0, 22.0], [13.0, 24.0]]),
         )
 
@@ -323,9 +321,7 @@ class TestExpression:
 
         result = a - b
 
-        _assert_expression_equals(
-            result, ExprTree("ConstExpression"), torch.tensor(7.0)
-        )
+        _assert_expression_equals(result, ExprTree("Constant"), torch.tensor(7.0))
 
     def test_negation(self):
         """Test that -expr creates ProductExpression(-1, expr)."""
@@ -337,7 +333,7 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree("Variable(x)"),
                 is_commutative=True,
             ),
@@ -354,7 +350,7 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree("Variable(x)"),
                 is_commutative=True,
             ),
@@ -386,9 +382,7 @@ class TestExpression:
 
         result = 2 * (a + b)
 
-        _assert_expression_equals(
-            result, ExprTree("ConstExpression"), torch.tensor(16.0)
-        )
+        _assert_expression_equals(result, ExprTree("Constant"), torch.tensor(16.0))
 
     def test_division_as_multiplication(self):
         """Test that expr / 2 becomes expr * 0.5."""
@@ -400,7 +394,7 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree("Variable(x)"),
                 is_commutative=True,
             ),
@@ -440,13 +434,13 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(x)"),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                     is_commutative=True,
                 ),
@@ -505,7 +499,7 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree(
                     "ProductExpression",
                     ExprTree("Variable(a)"),
@@ -527,8 +521,8 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
+                ExprTree("Constant"),
             ),
             torch.tensor([[19.0, 22.0], [43.0, 50.0]]),
         )
@@ -545,7 +539,7 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree(
                     "AddExpression",
                     ExprTree("Variable(x)"),
@@ -606,7 +600,7 @@ class TestExpression:
             result,
             ExprTree(
                 "ProductExpression",
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree("SumSquares", ExprTree("Variable(x)")),
                 is_commutative=True,
             ),
@@ -646,19 +640,19 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(x)"),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(z)"),
                     is_commutative=True,
                 ),
@@ -680,13 +674,13 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(x)"),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                     is_commutative=True,
                 ),
@@ -710,20 +704,20 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree(
                         "ProductExpression",
-                        ExprTree("ConstExpression"),
+                        ExprTree("Constant"),
                         ExprTree("Variable(x)"),
                     ),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree(
                         "ProductExpression",
-                        ExprTree("ConstExpression"),
+                        ExprTree("Constant"),
                         ExprTree("Variable(y)"),
                     ),
                     is_commutative=True,
@@ -747,21 +741,21 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree(
                         "ProductExpression",
-                        ExprTree("ConstExpression"),
+                        ExprTree("Constant"),
                         ExprTree("Variable(x)"),
                     ),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                     is_commutative=True,
                 ),
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 is_commutative=True,
             ),
             torch.tensor([[41.0]]),
@@ -782,7 +776,7 @@ class TestExpression:
                 ExprTree("L1Norm", ExprTree("Variable(x)")),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                     is_commutative=True,
                 ),
@@ -805,14 +799,14 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(x)"),
                     is_commutative=True,
                 ),
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                 ),
                 is_commutative=True,
@@ -833,17 +827,17 @@ class TestExpression:
                 "AddExpression",
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(x)"),
                     is_commutative=True,
                 ),
                 ExprTree(
                     "ProductExpression",
-                    ExprTree("ConstExpression"),
+                    ExprTree("Constant"),
                     ExprTree("Variable(y)"),
                     is_commutative=True,
                 ),
-                ExprTree("ConstExpression"),
+                ExprTree("Constant"),
                 is_commutative=True,
             ),
             torch.tensor(180.0),

--- a/tests/expression/test_product_expression.py
+++ b/tests/expression/test_product_expression.py
@@ -1,9 +1,11 @@
+"""Tests for ProductExpression class."""
+
 import pytest
 import torch
 
 from rlaopt.expression import (
     AddExpression,
-    ConstExpression,
+    Constant,
     Expression,
     ExprTree,
     Variable,
@@ -98,7 +100,7 @@ class TestProductExpression:
 
     def test_multiply_variable_and_constant_allowed(self, vector_var):
         """Test multiplying Variable and Constant is allowed."""
-        const = ConstExpression(5.0)
+        const = Constant(5.0)
         prod = ProductExpression(vector_var, const, matmul=False)
         assert prod.n_exprs == 2
 
@@ -110,9 +112,9 @@ class TestProductExpression:
     def test_multiply_expression_trees_of_vars_and_consts_allowed(
         self, vector_var, another_vector_var
     ):
-        """Test multiplying expressions built from Variables and Constants is allowed."""
+        """Test multiplying expressions built from Variables and Constants is allowed."""  # noqa: E501
         sum_expr = AddExpression(vector_var, another_vector_var)
-        const = ConstExpression(2.0)
+        const = Constant(2.0)
         prod = ProductExpression(sum_expr, const, matmul=False)
         assert prod.n_exprs == 2
 


### PR DESCRIPTION
Rename `ConstExpression` to `Constant` for ease-of-use.

Resolves #102