### PR TITLE
Add isotonic constraint

### DIFF
--- a/rlaopt/atoms/__init__.py
+++ b/rlaopt/atoms/__init__.py
@@ -5,6 +5,7 @@ from rlaopt.atoms.atom import AtomDecomposition as AtomDecomposition
 from rlaopt.atoms.box import Box as Box
 from rlaopt.atoms.elastic_net import ElasticNet as ElasticNet
 from rlaopt.atoms.halfspace import Halfspace as Halfspace
+from rlaopt.atoms.isotonic import Isotonic as Isotonic
 from rlaopt.atoms.l1_norm import L1Norm as L1Norm
 from rlaopt.atoms.l2_norm import L2Norm as L2Norm
 from rlaopt.atoms.linear_equality import LinearEquality as LinearEquality

--- a/rlaopt/atoms/isotonic.py
+++ b/rlaopt/atoms/isotonic.py
@@ -1,0 +1,150 @@
+"""Isotonic (monotonic non-decreasing) constraint atom for optimization."""
+
+from math import isclose
+from typing import Any
+from warnings import warn
+
+import torch
+from typing_extensions import Self
+
+from rlaopt.atoms.atom import Atom, AtomDecomposition
+from rlaopt.expression import Expression, Variable
+from rlaopt.ext_tensordict import TensorDict
+
+
+class Isotonic(Atom):
+    """Isotonic constraint enforcing ``x[0] <= x[1] <= ... <= x[n-1]``.
+
+    Args:
+        x: 1-D Expression to constrain to be non-decreasing.
+    """
+
+    def __init__(self, x: Expression):
+        """Initialize the isotonic constraint atom.
+
+        Args:
+            x: 1-D Expression to constrain to be non-decreasing.
+        """
+        super().__init__(exprs={"x": x}, buffers={})
+
+    def is_smooth(self) -> bool:
+        """Isotonic constraint is non-smooth."""
+        return False
+
+    def is_proxable(self) -> bool:
+        """Check if the proximal operator is computable."""
+        return isinstance(self.get_input("x"), Variable)
+
+    def forward(self) -> torch.Tensor:
+        """Evaluate the indicator of the isotonic constraint."""
+        value = self.get_input("x").forward()
+        satisfied = bool(torch.all(torch.diff(value) >= 0))
+        return _indicator(satisfied, value.device, value.dtype)
+
+    def _prox(
+        self, relevant_variable_values: TensorDict, prox_scaling: float
+    ) -> TensorDict:
+        """Compute the proximal operator of the isotonic constraint.
+
+        The projection is the prox of an indicator function, so it is independent of
+        ``prox_scaling``.
+        """
+        return relevant_variable_values.apply(_prox_isotonic.apply)
+
+    def decompose(self) -> list[AtomDecomposition] | None:
+        """Decompose the constraint if the input is affine."""
+        input_expr = self.get_input("x")
+        if not input_expr.is_affine():
+            return None
+
+        new_var = Variable.like(input_expr)
+        new_atom = type(self)(new_var)
+        return [AtomDecomposition(atom=new_atom, affine_expr=input_expr)]
+
+    def _scale(self, scaling: float) -> Self:
+        """Scale the constraint (scaling preserves the constraint set)."""
+        if isclose(scaling, 0.0):
+            warn(
+                f"Scaling a {self.__class__.__name__} constraint by zero has no effect."
+            )
+        return self
+
+
+class _prox_isotonic(torch.autograd.Function):
+    """Projection onto the isotonic cone via PAVA, with a custom backward pass.
+
+    The forward pass runs the O(n) stack-based Pool Adjacent Violators Algorithm to
+    compute the projection.
+
+    The projection is piecewise-linear: on each block the output is the block mean,
+    so its dependence on the input is local to that block. The backward pass therefore
+    reduces to a block-average of the incoming gradient over the same partition.
+    """
+
+    @staticmethod
+    def forward(ctx: Any, x: torch.Tensor) -> torch.Tensor:
+        """Project ``x`` onto the isotonic cone ``{x[0] <= ... <= x[n-1]}``.
+
+        Args:
+            ctx: Context object for saving information needed in the backward pass.
+            x: 1-D input tensor.
+
+        Returns:
+            The Euclidean projection of ``x`` onto the isotonic cone.
+        """
+        # A plain Python list of floats (no device),
+        # so the sequential PAVA loop avoids per-element device->host syncs.
+        vals = x.detach().tolist()
+
+        # Stack-based O(n) PAVA: each element is pushed once and total pops <= n.
+        block_sum: list[float] = []
+        block_cnt: list[int] = []
+        for v in vals:
+            s, c = v, 1
+            while block_sum and block_sum[-1] / block_cnt[-1] > s / c:
+                s += block_sum.pop()
+                c += block_cnt.pop()
+            block_sum.append(s)
+            block_cnt.append(c)
+
+        # Realize the projection on x's device/dtype as a per-block mean of x.
+        num_blocks = len(block_cnt)
+        block_id = torch.repeat_interleave(
+            torch.arange(num_blocks, device=x.device),
+            torch.tensor(block_cnt, device=x.device),
+        )
+        sums = x.new_zeros(num_blocks).index_add_(0, block_id, x)
+        counts = x.new_zeros(num_blocks).index_add_(0, block_id, torch.ones_like(x))
+        y = (sums / counts)[block_id]
+
+        ctx.save_for_backward(block_id)
+        ctx.num_blocks = num_blocks
+        return y
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: torch.Tensor) -> torch.Tensor:
+        """Block-average the incoming gradient over the saved PAVA partition.
+
+        Args:
+            ctx: Context object containing the saved block partition.
+            grad_output: Gradient of the loss with respect to the output.
+
+        Returns:
+            Gradient of the loss with respect to the input.
+        """
+        (block_id,) = ctx.saved_tensors
+        num_blocks = ctx.num_blocks
+        gsum = grad_output.new_zeros(num_blocks).index_add_(0, block_id, grad_output)
+        gcnt = grad_output.new_zeros(num_blocks).index_add_(
+            0, block_id, torch.ones_like(grad_output)
+        )
+        return (gsum / gcnt)[block_id]
+
+
+def _indicator(
+    satisfied: bool, device: torch.device, dtype: torch.dtype
+) -> torch.Tensor:
+    """Return 0 if satisfied, infinity otherwise."""
+    if satisfied:
+        return torch.tensor(0.0, device=device, dtype=dtype)
+    return torch.tensor(torch.inf, device=device, dtype=dtype)

--- a/tests/atoms/test_isotonic.py
+++ b/tests/atoms/test_isotonic.py
@@ -1,0 +1,122 @@
+"""Tests for the isotonic constraint atom."""
+
+import pytest
+import torch
+from tensordict import assert_allclose_td
+
+from rlaopt.atoms import Isotonic, SumSquares
+from rlaopt.atoms.isotonic import _prox_isotonic
+from rlaopt.expression import Variable
+from rlaopt.ext_tensordict import TensorDict
+
+
+@pytest.fixture
+def vector_var():
+    """Create a vector variable."""
+    return Variable((4,), name="x")
+
+
+class TestIsotonic:
+    """Tests for Isotonic atom."""
+
+    def test_forward_satisfied_and_violated(self, vector_var):
+        """Forward returns 0 if non-decreasing and inf otherwise."""
+        atom = Isotonic(vector_var)
+        vector_var.value = torch.tensor([1.0, 1.0, 2.0, 3.0])
+        assert torch.allclose(atom.forward(), torch.tensor(0.0))
+
+        vector_var.value = torch.tensor([1.0, 3.0, 2.0, 4.0])
+        assert torch.isinf(atom.forward())
+
+    def test_is_smooth_and_proxable(self, vector_var):
+        """Isotonic is nonsmooth and proxable for Variable input."""
+        atom = Isotonic(vector_var)
+        assert atom.is_smooth() is False
+        assert atom.is_proxable() is True
+
+    def test_is_proxable_false_for_expression(self, vector_var):
+        """Isotonic is not proxable when input is not a Variable."""
+        A = torch.eye(4)
+        b = torch.ones(4)
+        atom = Isotonic(A @ vector_var + b)
+        assert atom.is_proxable() is False
+
+    def test_prox_projects_onto_cone(self, vector_var):
+        """Prox projects a fully-decreasing point to the overall mean."""
+        atom = Isotonic(vector_var)
+        location = TensorDict({vector_var.name: torch.tensor([3.0, 2.0, 1.0, 0.0])})
+        result = atom.prox(location, prox_scaling=1.0)
+        expected = TensorDict({vector_var.name: torch.tensor([1.5, 1.5, 1.5, 1.5])})
+        assert_allclose_td(result, expected)
+
+    def test_prox_matches_pava_reference(self, vector_var):
+        """Prox matches a hand-computed PAVA result with a pooled middle block."""
+        atom = Isotonic(vector_var)
+        location = TensorDict({vector_var.name: torch.tensor([1.0, 3.0, 2.0, 4.0])})
+        result = atom.prox(location, prox_scaling=1.0)
+        expected = TensorDict({vector_var.name: torch.tensor([1.0, 2.5, 2.5, 4.0])})
+        assert_allclose_td(result, expected)
+
+    def test_prox_preserves_feasible_point(self, vector_var):
+        """Prox leaves an already non-decreasing point unchanged."""
+        atom = Isotonic(vector_var)
+        location = TensorDict({vector_var.name: torch.tensor([1.0, 2.0, 2.0, 5.0])})
+        result = atom.prox(location, prox_scaling=1.0)
+        assert_allclose_td(result, location)
+
+    def test_prox_idempotent(self, vector_var):
+        """Projecting twice equals projecting once."""
+        atom = Isotonic(vector_var)
+        location = TensorDict({vector_var.name: torch.tensor([4.0, 1.0, 3.0, 2.0])})
+        once = atom.prox(location, prox_scaling=1.0)
+        twice = atom.prox(once, prox_scaling=1.0)
+        assert_allclose_td(twice, once)
+
+    def test_decompose_affine_and_non_affine(self, vector_var):
+        """Decompose works for affine inputs and returns None for non-affine."""
+        A = torch.eye(4)
+        b = torch.ones(4)
+        affine_expr = A @ vector_var + b
+        atom = Isotonic(affine_expr)
+        decompositions = atom.decompose()
+        assert decompositions is not None
+        assert len(decompositions) == 1
+        assert decompositions[0].affine_expr is affine_expr
+
+        non_affine = SumSquares(vector_var)
+        atom_non_affine = Isotonic(non_affine)
+        assert atom_non_affine.decompose() is None
+
+    def test_scaling_returns_same_atom(self, vector_var):
+        """Scaling an isotonic constraint returns the same atom (identity)."""
+        atom = Isotonic(vector_var)
+        scaled = 5.0 * atom
+        assert scaled is atom
+
+    def test_scaling_by_zero_warns(self, vector_var):
+        """Scaling by zero raises a warning but still returns the same atom."""
+        atom = Isotonic(vector_var)
+        with pytest.warns(UserWarning, match="Scaling a Isotonic.*by zero"):
+            scaled = 0.0 * atom
+        assert scaled is atom
+
+    def test_prox_gradient_flows_through(self, vector_var):
+        """Prox allows gradient computation without NaNs."""
+        atom = Isotonic(vector_var)
+        location_tensor = torch.tensor([3.0, 1.0, 5.0, 2.0], requires_grad=True)
+        location = TensorDict({vector_var.name: location_tensor})
+
+        result = atom.prox(location, prox_scaling=1.0)
+        result[vector_var.name].sum().backward()
+
+        assert location_tensor.grad is not None
+        assert not torch.isnan(location_tensor.grad).any()
+
+    def test_prox_gradcheck(self):
+        """Gradcheck the projection at an interior point of a fixed-block region."""
+        # Blocks {0,1}, {2,3}, {4} with distinct means (2.0, 3.5, 8.0), so the
+        # partition is locally stable and the projection is locally linear.
+        x = torch.tensor(
+            [3.0, 1.0, 5.0, 2.0, 8.0], dtype=torch.float64, requires_grad=True
+        )
+        assert torch.autograd.gradcheck(_prox_isotonic.apply, (x,))


### PR DESCRIPTION
## Summary
Adds an `Isotonic` constraint atom: the indicator of the monotone cone `{x : x[0] <= x[1] <= ... <= x[n-1]}`. Its proximal operator is the Euclidean projection onto the cone, computed by an **O(n)** stack-based Pool Adjacent Violators Algorithm (PAVA).

## Differentiability
The projection is a custom `torch.autograd.Function`. PAVA partitions the indices into blocks on which the output is the block mean, so the projection is piecewise-linear and its **backward is just the block-average of the upstream gradient** over the same partition — no matmul, no materialized Jacobian. This is grounded in the KKT/dual structure: the block partition is exactly the support of the dual variables (`λ_i = V_i − X_i`, zero at block boundaries).

## Design notes
- Operates on **1-D vectors**; no flattening (order *is* the constraint). No explicit shape check, consistent with `NucNorm`.
- `_scale` is a no-op that warns on zero scaling, matching the `Polyhedron` family.
- PAVA structure detection runs host-side (sequential, O(n)); all tensor math stays on the input's device.

## Tests (`tests/atoms/test_isotonic.py`)
Forward indicator, prox vs hand-computed PAVA references, idempotency, feasibility preservation, decompose, `_scale` (no-op + zero warning), gradient flow through the `prox` API, and a float64 `gradcheck` of the custom backward. All 12 pass; full `tests/atoms` suite (1428) green; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)